### PR TITLE
[Content] Proposal: Remove Anaconda references

### DIFF
--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -92,12 +92,18 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
           <li>Download the Anaconda Installer with Python 3 for macOS (you can either use the Graphical or the Command Line Installer).</li>
           <li>Install Python 3 by running the Anaconda Installer using all of the defaults for installation.</li>
         </ol>
+
         <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/TcSAln46u9U?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
+        (Coming soon)
+
+        <!--
+          <h4>Video Tutorial</h4>
+          <div class="yt-wrapper2">
+          <div class="yt-wrapper">
+          <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/TcSAln46u9U?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
+          </div>
+          </div>
+        -->
       </article>
       <article role="tabpanel" class="tab-pane" id="python-linux">
         <ol>

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -74,6 +74,9 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
           </ul>
         </ol>
 
+        <h4>Video Tutorial</h4>
+        (Coming soon)
+
         <!--
           <h4>Video Tutorial</h4>
           <div class="yt-wrapper2">

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -52,12 +52,15 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
           <li>Download the Anaconda for Windows installer with Python 3. (If you are not sure which version to choose, you probably want the 64-bit Graphical Installer <em>Anaconda3-...-Windows-x86_64.exe</em>)</li>
           <li>Install Python 3 by running the Anaconda Installer, using all of the defaults for installation <em>except</em> make sure to check <strong>Add Anaconda to my PATH environment variable</strong>.</li>
         </ol>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/xxQ0mzZ8UvA?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
+
+        <!--
+          <h4>Video Tutorial</h4>
+          <div class="yt-wrapper2">
+          <div class="yt-wrapper">
+          <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/xxQ0mzZ8UvA?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
+          </div>
+          </div>
+        -->
       </article>
       <article role="tabpanel" class="tab-pane" id="python-macos">
         <ol>

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -11,16 +11,25 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
   <p>
     <a href="https://python.org">Python</a> is a popular language for
     research computing, and great for general-purpose programming as
-    well.  Installing all of its research packages individually can be
-    a bit difficult, so we recommend
-    <a href="https://www.anaconda.com/download/success">Anaconda</a>,
-    an all-in-one installer.
+    well. Python at it's core contains a number of useful libraries
+    that are used in most scientific applications, however there are
+    a number of third party libraries that are provided free of charge
+    that can be used to extend the functionality of Python. We will
+    cover the installation and use of these libraries in the workshop.
   </p>
 
   <p>
     Regardless of how you choose to install it,
     <strong>please make sure you install Python version 3.x</strong>
-    (e.g., 3.6 is fine).
+    (e.g., "3.6.1" or "3.11.6" is fine).
+  </p>
+
+  <p>
+    You can check if you have a working installation by opening a
+    command line (on Windows), or terminal (on macOS and Linux) and
+    typing <code>python --version</code> or <code>python3 --version</code>, then pressing
+    <kbd>Enter</kbd>. You should see something like <code>Python 3.12.6</code> appear in the
+    console window.
   </p>
 
   {% comment %}
@@ -47,10 +56,22 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
 
     <div class="tab-content">
       <article role="tabpanel" class="tab-pane active" id="python-windows">
+        To install Python on a Windows machine, follow these steps:
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda for Windows installer with Python 3. (If you are not sure which version to choose, you probably want the 64-bit Graphical Installer <em>Anaconda3-...-Windows-x86_64.exe</em>)</li>
-          <li>Install Python 3 by running the Anaconda Installer, using all of the defaults for installation <em>except</em> make sure to check <strong>Add Anaconda to my PATH environment variable</strong>.</li>
+          <li>Open <a href="https://www.python.org/downloads/">https://www.python.org/downloads/</a> with your web browser.</li>
+          <li>Click on the large yellow button that says "Download Python 3.XX.XX" (the actual version will depend on the most recent release)</li>
+          <li>A short download should begin.</li>
+          <li>Once the installer is downloaded, run the installer by double-clicking it.</li>
+          <li>Make sure the following options are selected:</li>
+          <ul>
+            <li>Install launcher for all users (recommended)</li>
+            <li>"Add Python to PATH"</li>
+            <li>(Optional Features) pip</li>
+          </ul>
+          <li>Verify the installation by opening a command prompt and typing <code>python --version</code>.</li>
+          <ul>
+            <li>If you see a version number like <code>Python 3.12.6</code>, then you are ready for the workshop!</li>
+          </ul>
         </ol>
 
         <!--

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -88,9 +88,12 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
       </article>
       <article role="tabpanel" class="tab-pane" id="python-macos">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda Installer with Python 3 for macOS (you can either use the Graphical or the Command Line Installer).</li>
-          <li>Install Python 3 by running the Anaconda Installer using all of the defaults for installation.</li>
+          <li>Open <a href="https://www.python.org/downloads/">https://www.python.org/downloads/</a> with your web browser.</li>
+          <li>Download the Python installer for macOS.</li>
+          <li>Run the downloaded installer.</li>
+          <li>Make sure to check the box that says "Add Python to PATH" and ensure that pip is included in the installation.</li>
+          <li>Follow the remaining installation instructions provided by the installer.</li>
+          <li>Verify the installation by opening a terminal and typing <code>python3 --version</code> and <code>pip3 --version</code>.</li>
         </ol>
 
         <h4>Video Tutorial</h4>
@@ -107,38 +110,28 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
       </article>
       <article role="tabpanel" class="tab-pane" id="python-linux">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda Installer with Python 3 for Linux.<br>
-            (The installation requires using the shell. If you aren't
-            comfortable doing the installation yourself
-            stop here and request help at the workshop.)
-          </li>
-          <li>
-            Open a terminal window and navigate to the directory where
-            the executable is downloaded (e.g., `cd ~/Downloads`).
-          </li>
-          <li>
-            Type <pre>bash Anaconda3-</pre> and then press
-            <kbd>Tab</kbd> to autocomplete the full file name. The name of
-            file you just downloaded should appear.
-          </li>
-          <li>
-            Press <kbd>Enter</kbd>
-            (or <kbd>Return</kbd> depending on your keyboard).
-            You will follow the text-only prompts.
-            To move through the text, press <kbd>Spacebar</kbd>.
-            Type <code>yes</code> and press enter to approve the license.
-            Press <kbd>Enter</kbd> (or <kbd>Return</kbd>)
-            to approve the default location
-            for the files.
-            Type <code>yes</code> and press
-            <kbd>Enter</kbd> (or <kbd>Return</kbd>)
-            to prepend Anaconda to your <code>PATH</code>
-            (this makes the Anaconda distribution the default Python).
-          </li>
-          <li>
-            Close the terminal window.
-          </li>
+          <li>Open <a href="https://www.python.org/downloads/source/">https://www.python.org/downloads/source/</a> with your web browser.</li>
+          <li>Select the link at the top which reads "Latest Python3 Release - Python 3.XX.XX" (The actual version will depend on the most recent release)</li>
+          <li>Scroll to the "Files" section on the next page, and download the "Gzipped source tarball"</li>
+          <li>Open a terminal window and navigate to the directory where the file is downloaded (e.g., <code>cd ~/Downloads</code>).</li>
+          <li>Extract the file with the command <code>tar -xvzf Python-{version}.tgz</code> (where {version} is the actual version number downloaded)</li>
+          <li>Change to the extracted directory with the command <code>cd Python-{version}</code></li>
+          <li>Run the following commands to compile and install Python:</li>
+          <ul>
+            <li>
+              <code>
+                ./configure <br>
+                &nbsp;&nbsp;--prefix=/opt/python/${PYTHON_VERSION} <br>
+                &nbsp;&nbsp;--enable-shared <br>
+                &nbsp;&nbsp;--enable-optimizations <br>
+                &nbsp;&nbsp;--enable-ipv6 <br>
+                &nbsp;&nbsp;LDFLAGS=-Wl,-rpath=/opt/python/${PYTHON_VERSION}/lib,--disable-new-dtags
+              </code>
+            </li>
+            <li><code>make</code></li>
+            <li><code>sudo make install</code></li>
+          </ul>
+          <li>Verify the installation by opening a terminal and typing <code>python3 --version</code> and <code>pip3 --version</code>.</li>
         </ol>
       </article>
     </div>


### PR DESCRIPTION
A potential change to the setup section, given the issue raised by Marc-André around the use of Anaconda. 

Given the amount of time we have in the workshop, it might be worthwhile to have the participants install base python rather than anaconda, and then cover `pip install`ing libraries as a quick section at the start. 

Potentially this might introduce issues with people who are unable to get jupyter lab up and running, so the alternative would be to have them install anaconda, then use the `conda-forge` channel. 